### PR TITLE
Bump Countly dependency to 17.09.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   }
 
   provided 'com.segment.analytics.android:analytics:4.0.9'
-  compile 'ly.count.android:sdk:17.09'
+  compile 'ly.count.android:sdk:17.09.1'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.4.2') {


### PR DESCRIPTION
- Bumps Countly dep to latest, v17.09.1
- No currently used methods are deprecated
- All unit tests still pass
- Circle still passes